### PR TITLE
Delete needless after_script section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
 language: node_js
 node_js:
   - '0.12'
-
-after_script:
-  - npm run tests


### PR DESCRIPTION
Travis runs `npm test` independently. You not need to do it manually.
